### PR TITLE
Add shared stylesheet for hello world apps

### DIFF
--- a/Guides/helloworld.css
+++ b/Guides/helloworld.css
@@ -1,0 +1,19 @@
+@import url("http://fonts.googleapis.com/css?family=Titillium+Web:300");
+
+html {
+	margin: 0;
+	padding: 0;
+	background: url("http://www.cloudcontrol.com/assets/bg_noise.jpg") repeat fixed;
+	font-family: 'Titillium Web';
+	font-weight: 200;
+}
+
+
+body {
+	height: 100%;
+	margin: 0;
+	padding: 1ex;
+	text-align: center;
+	font-size: 300%;
+	background: url("../images/rocket.png") center bottom / auto 75% no-repeat fixed;
+}


### PR DESCRIPTION
This time in a hopefully safe location!

Rationale:
- the CSS is located logically close to the Guides that use them
- the url (https://www.cloudcontrol.com/documentation/Guides/helloworld.css) looks sensible
- the CSS is unversioned, so we can change it without having to change all the example-repositories
