### PR TITLE
Clarify SSL / alias docs

### DIFF
--- a/Add-on Documentation/Deployment/Alias.md
+++ b/Add-on Documentation/Deployment/Alias.md
@@ -1,6 +1,9 @@
 # Alias Add-on
 
-Adding custom domains to a deployment is supported via the Alias add-on. The process requires basic knowledge about how the DNS system works. To add a custom domain follow the following simple steps **for each domain**.
+Adding custom domains to a deployment is supported via the Alias add-on. The
+process requires basic knowledge about how the DNS system works. To add a
+custom domain follow the following simple steps **for each domain**.
+
 
 ## Adding an Alias
 

--- a/Add-on Documentation/Deployment/SSL.md
+++ b/Add-on Documentation/Deployment/SSL.md
@@ -1,40 +1,22 @@
 # SSL Add-on
 
-Overview:
+This add-on provides SSL support for custom domains (e.g. "www.example.com")
+that you have added to your application using the [alias addon](https://www.cloudcontrol.com/dev-center/Add-on%20Documentation/Deployment/Alias).
 
- * This Add-on provides SSL support for custom domains.
- * You need to have an RSA Private Key, an SSL Certificate and a Certificate Chain.
- * Add the Add-on to your deployment via our CLI with the [addon.add command](#adding-the-ssl-add-on).
 
-Secure Socket Layer (SSL) encryption is available for improved security when
-transmitting passwords and other sensitive data.
-
-As part of the provided `.cloudcontrolled.com` subdomain, all deployments have
-access to piggyback SSL using a `*.cloudcontrolled.com` wildcard certificate.
-To use this, simply point your browser to:
-* `https://APP_NAME.cloudcontrolled.com` for the default deployment
-* `https://DEP_NAME-APP_NAME.cloudcontrolled.com` for non-default deployments
-
-    Please note the **dash** between DEP_NAME and APP_NAME.
-
-SSL support for custom domains is available through the SSL Add-on.
-
-## Custom Domain Certificates
-
-To enable SSL support for custom domains like `www.example.com` or
-`secure.example.com`, you need the SSL Add-on.
+## Overview
 
 Please go through the following steps, which are described in the upcoming
-sections, to add SSL support to your deployment:
+sections, to add SSL support for custom domains to your deployment:
 
  * Acquire a signed certificate from your certificate authority of trust.
- * Add the SSL Add-on providing the certificate, the private key and the
+ * Add the SSL add-on providing the certificate, the private key and the
    certificate-chain files.
  * Set your DNS entry to point to your SSL DNS Domain.
 
-Note: Please allow up to one hour for DNS changes to propagate before they take
-effect. Root or naked domains like `example.com` without a subdomain are not
-supported.
+Root or naked domains like `example.com` without a subdomain are not
+directly supported. For details, please see the [alias addon](https://www.cloudcontrol.com/dev-center/Add-on%20Documentation/Deployment/Alias) documentation.
+
 
 ### Acquiring an SSL Certificate
 
@@ -169,9 +151,9 @@ In order to check the status of the Add-on, you can do the following.
  Addon                    : ssl.host
 
  Settings
-   SSLDEV_CERT_EXPIRES      : 2016-01-01 10:00:00
-   SSLDEV_DNS_DOMAIN        : addonssl-depxxxxxxxx-1234567890.eu-west-1.elb.amazonaws.com
-   SSLDEV_CERT_INCEPTS      : 2013-01-01 10:00:00
+   SSL_CERT_EXPIRES      : 2016-01-01 10:00:00
+   SSL_DNS_DOMAIN        : addonssl-depxxxxxxxx-1234567890.eu-west-1.elb.amazonaws.com
+   SSL_CERT_INCEPTS      : 2013-01-01 10:00:00
  ~~~
 
 When the SSL certificate is expired, you can update it by removing the Add-on
@@ -186,6 +168,14 @@ following commands:
 
 Note: You need to provide the original key and chain again when updating the
 Add-on even if those are not changed.
+
+
+### Setup your DNS
+
+As a final step, create a corresponding CNAME entry and point it to the
+SSL_DNS_DOMAIN shown in the configuration for your SSL add-on as seen
+above.
+
 
 ## HTTPS Redirects
 

--- a/Platform Documentation.md
+++ b/Platform Documentation.md
@@ -555,6 +555,22 @@ All custom domains need to be verified before they start working. To verify a do
 
 Changes to DNS can take up to 24 hours until they have effect. Please refer to the Alias Add-on Documentation for detailed instructions on how to setup CNAME and TXT records.
 
+### Root Domains
+
+Root domains (e.g. "example.com") can also be added but are not directly
+supported. While you theoretically can add a CNAME record for your root
+domain, you have to be aware that no other record for this domain can
+be set then. ("A CNAME record is not allowed to coexist with any other
+data", http://tools.ietf.org/html/rfc1912). From the point you set a
+CNAME, all standard-compliant DNS servers will ignore any other entry you
+might have set for your zone (e.g. SOA, NS or MX records).
+
+You can circumvent this limitation by using a DNS provider which provides
+CNAME-like functionality for root domains, often called ANAME or ALIAS.
+
+An alternative is to use a redirection service to send users from the
+root to the configured subdomain (e.g. example.org -> www.example.org).
+
 
 ## Routing Tier
 
@@ -570,6 +586,25 @@ Changes to DNS can take up to 24 hours until they have effect. Please refer to t
 All HTTP requests made to apps on the platform are routed via our routing tier. The routing tier is designed as a cluster of reverse proxy loadbalancers which orchestrate the forwarding of user requests to your applications. It takes care of routing the request to one of the application's containers based on matching the `Host` header against the list of the deployment's aliases. This is accomplished via the `*.cloudcontrolled.com` or `*.cloudcontrolapp.com` subdomains.
 
 The routing tier is designed to be robust against single node and even complete datacenter failures while still keeping the added latency as low as possible.
+
+### SSL
+
+Transport Layer Security (TLS / SSL) is available to encrypt traffic between
+users and applications.
+
+As part of the provided `.cloudcontrolled.com` subdomain, all deployments have
+access to piggyback SSL using a `*.cloudcontrolled.com` wildcard certificate.
+To use this, simply point your browser to:
+* `https://APP_NAME.cloudcontrolled.com` for the default deployment
+* `https://DEP_NAME-APP_NAME.cloudcontrolled.com` for non-default deployments
+
+    Please note the **dash** between DEP_NAME and APP_NAME.
+
+SSL support for custom domains is available through the
+[SSL add-on](https://www.cloudcontrol.com/add-ons/ssl).
+
+Instructions on how to add HTTPS redirects to your application can be
+found in the [SSL add-on documentation](https://www.cloudcontrol.com/dev-center/Add-on%20Documentation/Deployment/SSL#https-redirects).
 
 ### Elastic Addresses
 


### PR DESCRIPTION
Move general information on SSL from the SSL add-on documentation to the
platform documentation.

Explicitly talk about root domains and what can be done to use one with
cloudControl.

Add an extra paragraph on the required DNS settings for add-on SSL.
