### PR TITLE
Add-on/Config: no creds available during build

### DIFF
--- a/Add-on Documentation/Deployment/Custom Config.md
+++ b/Add-on Documentation/Deployment/Custom Config.md
@@ -1,15 +1,22 @@
 # Custom Config Add-on
 
 The Custom Config Add-on allows you to add custom credentials to the standard
-creds.json file provided for each of your deployments. This makes it possible for you to keep your code in separate branches, each with their own configuration settings.
+creds.json file provided for each of your deployments. This makes it possible
+for you to keep your code in separate branches, each with their own
+configuration settings.
 
-An example for where you may need such a configuration are the Amazon S3 credentials. In this case, you
-likely want to use different credentials for production and development. The Custom Config Add-on allows you to do this.
+An example for where you may need such a configuration are the Amazon S3
+credentials. In this case, you likely want to use different credentials for
+production and development. The Custom Config Add-on allows you to do this.
+
+Note: during the build (push), the credentials / creds.json are not
+available.
 
 ## Adding Configuration Settings
 
 To add configuration settings, simply invoke the config command with the add
 option, and append the desired `key` / `value` pairs.
+
 ~~~bash
 $ cctrlapp APP_NAME/DEP_NAME config.add KEY=VALUE
 ~~~
@@ -19,12 +26,16 @@ This will automatically add the Config Add-on to your deployment.
 Replace APP_NAME, DEP_NAME, KEY and VALUE with the desired values and they will
 be added to your deployment's cred.json file.
 
-To set multiple settings at once, simply append more than one `key` / `value` pair.
+To set multiple settings at once, simply append more than one `key` / `value`
+pair.
+
 ~~~bash
 $ cctrlapp APP_NAME/DEP_NAME config.add KEY1=VALUE1 KEY2=VALUE2 [...]
 ~~~
 
-Config parameters can be set using the format shown in first column of the following table. They are then stored in JSON format, as shown in the second column. Multiline arguments can be set using the `\n` escape character.
+Config parameters can be set using the format shown in first column of the
+following table. They are then stored in JSON format, as shown in the second
+column. Multiline arguments can be set using the `\n` escape character.
 
 CLI parameter|JSON representation
 ---|---
@@ -40,6 +51,7 @@ multiline values to make sure they are stored properly.
 
 You can list the existing set of configuration settings by invoking the config
 command:
+
 ~~~bash
 $ cctrlapp APP_NAME/DEP_NAME config
 KEY1=VALUE1
@@ -47,6 +59,7 @@ KEY2=VALUE2
 ~~~
 
 To show the value of a specific key, simply append the desired key name:
+
 ~~~bash
 $ cctrlapp APP_NAME/DEP_NAME config KEY
 VALUE
@@ -56,6 +69,7 @@ VALUE
 
 To add or remove settings to your custom config, simply use the `add` or
 `remove` option of the config command and append the parameters you need.
+
 ~~~bash
 $ cctrlapp APP_NAME/DEP_NAME config.add [-f|--force] NEW_PARAM=NEW_VALUE [...]
 $ cctrlapp APP_NAME/DEP_NAME config.remove PARAM1 PARAM2 [...]
@@ -67,11 +81,11 @@ the add command.
 
 ## Removing the Config Addon
 
-Deleting all the existing configuration settings from a deployment can be done by
-removing the Add-on.
+Deleting all the existing configuration settings from a deployment can be done
+by removing the Add-on.
+
 ~~~bash
 $ cctrlapp APP_NAME/DEP_NAME addon.remove config.free
 ~~~
 
 This will remove all the custom configuration settings.
-


### PR DESCRIPTION
Emphazize that credentials are not available during the build.

Also, limit line length to <= 80.
