### PR TITLE
Adapt mysqld addon guide for Google SQL implementation

### DIFF
--- a/Add-on Documentation/Data Storage/MySQLd.md
+++ b/Add-on Documentation/Data Storage/MySQLd.md
@@ -2,13 +2,9 @@
 
 High-availability, dedicated MySQL databases are available for
 mission-critical production deployments. The dedicated MySQL Add-on is
-based on [Amazon RDS] and uses master-slave replicated Multi-AZ instances. Read
-slaves or reserved instances are currently not supported via the Add-on, but
-you can always create a custom RDS instance in the EU region and connect your
-app to it. We recommend using the [Config Add-on] to make the credentials
-of the self-managed RDS instance available to your app.
+based on [Google Cloud SQL] and synchronous replication in multiple zones.
 
-## Features of the cloudControl MySQLd Add-on
+## Features of the dotCloud MySQLd Add-on
 
 The MySQLd Add-on comes with the following features:
 
@@ -26,33 +22,37 @@ The MySQLd Add-on comes with the following features:
     - DB Snapshots - DB Snapshots are available. [Email us] for more details.
 
 3. High Availability
-    - Multi-AZ Deployments - Once you create or modify your DB Instance, we
-    will automatically provision and manage a “standby” replica in a
-    different Availability Zone (independent infrastructure in a physically
-    separate location). Database updates are made concurrently on the primary
-    and standby resources to prevent replication lag.
+    - Multiple Zones Data Replication - Your data is replicated in many geographic locations
+    as standard. Failover between them is handled automatically by us. Your data is
+    safe and your database is available even in the event of a major failure in one location.
 
 4. Dashboard
-    - View key operational metrics like CPU/ Memory/ Storage/ Connections/ Upgrade status for your DB Instance deployments via [Webconsole].
+    - View key operational metrics like Storage or Connections for your DB Instance deployments via [Webconsole]. 
+    - Download the SSL Certificate for encrypted external connections. 
+
+5. Security
+    - All data is encrypted when on internal networks and when stored in database
+    tables and temporary files.
+    - Connections can be encrypted using SSL.
 
 ## Adding the MySQLd Add-on
 
 To add the MySQLd Add-on use the `addon.add` command:
 
 ~~~
-$ cctrlapp APP_NAME/DEP_NAME addon.add mysqld.OPTION
+$ dcapp APP_NAME/DEP_NAME addon.add mysqld.OPTION
 ~~~
-Replace `mysqld.OPTION` with a valid option, e.g. `mysqld.small`. See
+Replace `mysqld.OPTION` with a valid option, e.g. `mysqld.d0`. See
 [MySQLd] in the Add-on Marketplace for pricing and options.
 
-Please note: After adding a dedicated MySQL database, it can take up to 30 minutes before the instance is available. Also the credentials will only be available after the instance is up and running.
+Please note: After adding a dedicated MySQL database, it can take up to 5 minutes before the instance is available. Also the credentials will only be available after the instance is up and running.
 
 ## Upgrading the MySQLd Add-on
 
 To upgrade from a smaller to a more powerful plan use the `addon.upgrade` command:
 
 ~~~
-$ cctrlapp APP_NAME/DEP_NAME addon.upgrade mysqld.OPTION_OLD mysqld.OPTION_NEW
+$ dcapp APP_NAME/DEP_NAME addon.upgrade mysqld.OPTION_OLD mysqld.OPTION_NEW
 ~~~
 
 Please note: Upgrading the instance types is a multi step process that first upgrades the secondary, then promotes the secondary to the new master and after that upgrades also the old master and makes it the new secondary. This process can take up to 65 minutes and can involve a 3 to 10 minute downtime.
@@ -62,7 +62,7 @@ Please note: Upgrading the instance types is a multi step process that first upg
 To downgrade to a smaller plan, use the `addon.downgrade` command:
 
 ~~~
-$ cctrlapp APP_NAME/DEP_NAME addon.downgrade mysqld.OPTION_OLD mysqld.OPTION_NEW
+$ dcapp APP_NAME/DEP_NAME addon.downgrade mysqld.OPTION_OLD mysqld.OPTION_NEW
 ~~~
 
 Please note: It is only possible to downgrade to plans with matching storage
@@ -74,17 +74,18 @@ sizes.
 The MySQLd Add-on can be removed from the deployment by using the `addon.remove` command:
 
 ~~~
-$ cctrlapp APP_NAME/DEP_NAME addon.remove mysqld.OPTION
+$ dcapp APP_NAME/DEP_NAME addon.remove mysqld.OPTION
 ~~~
 
 **Attention:** Removing the MySQLd Add-on deletes all data in the database.
 
 ## Replication and Failover
 
-All instances are master-slave replicated across two different availability
-zones. In case of a failure of the master, an automatic failover to the slave
-will trigger to restore availability. This failover process takes usually
-between 3 and 10 minutes.
+All instances replicated in multiple zones. In the unlikely event of a zone outage,
+instances fail over to another, available, zone automatically. Failover is designed to
+be transparent to your applications, so that after failover, an instance has the same
+instance name, IP address, and firewall rules. During the failover there will typically
+be a few seconds downtime as the instance starts up in a new zone.
 
 ## Database Credentials
 
@@ -101,24 +102,24 @@ general documentation.
 
 External access to the MySQLd Add-on is available through an SSL-encrypted connection by following these simple steps:
 
- 1. Download the [certificate file] to your local machine.
+ 1. Download the SSL certificate file from the Dashboard via [Webconsole].
  1. Connect to the database using an SSL encrypted connection.
 
 The following example uses the MySQL command line tool:
 
 ~~~
-$ mysql -u MYSQLD_USERNAME -p --host=MYSQLD_HOSTNAME --ssl-ca=PATH_TO_CERTIFICATE/mysql-ssl-ca-cert.pem
+$ mysql -u MYSQLD_USERNAME -p --host=MYSQLD_HOSTNAME --ssl-ca=PATH_TO_CERTIFICATE/ca-cert.pem
 ~~~
 
 Replace the uppercase variables with the corresponding values shown by the `addon` command:
 
 ~~~
-$ cctrlapp APP_NAME/DEP_NAME addon mysqld.OPTION
-Addon                    : mysqld.small
+$ dcapp APP_NAME/DEP_NAME addon mysqld.OPTION
+Addon                    : mysqld.d0
  Settings
    MYSQLD_PASSWORD          : SOME_SECRET_PASSWORD
    MYSQLD_USER              : SOME_SECRET_USER
-   MYSQLD_HOST              : SOME_HOST.eu-west-1.rds.amazonaws.com
+   MYSQLD_HOST              : SOME_HOST
    MYSQLD_DATABASE          : SOME_DATABASE_NAME
    MYSQLD_PORT              : 3306
    MYSQLD_URL               : SOME_DATABASE_URL
@@ -128,19 +129,18 @@ Similarly, imports and exports are equally simple.
 
 To **export** your data use the `mysqldump` command:
 ~~~
-$ mysqldump -u MYSQLD_USERNAME -p --host=MYSQLD_HOSTNAME --ssl-ca=PATH_TO_CERTIFICATE/mysql-ssl-ca-cert.pem MYSQLD_DATABASE > MYSQLD_DATABASE.sql
+$ mysqldump -u MYSQLD_USERNAME -p --host=MYSQLD_HOSTNAME --ssl-ca=PATH_TO_CERTIFICATE/ca-cert.pem MYSQLD_DATABASE > MYSQLD_DATABASE.sql
 ~~~
 
 To **import** an sql file into a MySQL database use the following command:
 ~~~
-$ mysql -u MYSQLD_USER -p --host=MYSQLD_SERVER --ssl-ca=PATH_TO_CERTIFICATE/mysql-ssl-ca-cert.pem MYSQLD_DATABASE < MYSQLD_DATABASE.sql
+$ mysql -u MYSQLD_USER -p --host=MYSQLD_SERVER --ssl-ca=PATH_TO_CERTIFICATE/ca-cert.pem MYSQLD_DATABASE < MYSQLD_DATABASE.sql
 ~~~
 
 
-[Amazon RDS]: http://aws.amazon.com/rds/
+[Google Cloud SQL]: https://developers.google.com/cloud-sql/
 [Config Add-on]: https://www.cloudcontrol.com/add-ons/config
 [MySQLd]: https://www.cloudcontrol.com/add-ons/mysqld
 [Add-on Credentials]: https://www.cloudcontrol.com/dev-center/Platform%20Documentation#add-ons
 [Email us]: mailto:support@cloudcontrol.de
-[certificate file]: http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem
 [Webconsole]: https://www.cloudcontrol.com/console/login


### PR DESCRIPTION
We changed this guide preparing the next dotCloud story a while ago and got forgotten in this branch. Trying to get it merged into `dotcloudapp` branch, as it is the default work in process branch at the moment.
