### PR TITLE
Wrong syntax show-table-status command

### DIFF
--- a/Add-on Documentation/Data Storage/MySQLs.md
+++ b/Add-on Documentation/Data Storage/MySQLs.md
@@ -48,7 +48,7 @@ takes usually between 3 and 10 minutes.
 ## Encoding
 
 All databases and tables use `latin1` as the default character set. You can find the character set
-and collation of all your tables by running `SHOW STATUS TABLE;` under the `Collation` row.
+and collation of all your tables by running `SHOW TABLE STATUS;` under the `Collation` row.
 
 You can change the encoding of a table with this query:
 


### PR DESCRIPTION
Wrong syntax of: `SHOW STATUS TABLE;`
Cause:
mysql> SHOW STATUS TABLE;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'TABLE' at line 1