### PR TITLE
Update download link for RDS SSL bundle

### DIFF
--- a/Add-on Documentation/Data Storage/MySQLd.md
+++ b/Add-on Documentation/Data Storage/MySQLd.md
@@ -142,5 +142,5 @@ $ mysql -u MYSQLD_USER -p --host=MYSQLD_SERVER --ssl-ca=PATH_TO_CERTIFICATE/mysq
 [MySQLd]: https://www.cloudcontrol.com/add-ons/mysqld
 [Add-on Credentials]: https://www.cloudcontrol.com/dev-center/platform-documentation#add-ons
 [Email us]: mailto:support@cloudcontrol.de
-[certificate file]: http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem
+[certificate file]: https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
 [Webconsole]: https://www.cloudcontrol.com/console/login

--- a/Add-on Documentation/Data Storage/MySQLs.md
+++ b/Add-on Documentation/Data Storage/MySQLs.md
@@ -91,7 +91,7 @@ the general documentation.
 
 External access to the MySQLs Add-on is available through an SSL encrypted connection by following these simple steps.
 
- 1. Download the [certificate file](http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem) to your local machine.
+ 1. Download the [certificate file](https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem) to your local machine.
  1. Connect to the database using an SSL encrypted connection.
 
 The following example uses the MySQL command line tool.

--- a/Guides/PHP/CakePHP 2.2.1.md
+++ b/Guides/PHP/CakePHP 2.2.1.md
@@ -395,7 +395,7 @@ Now, in the shell, we're going to load the data in to the remote mysql instance 
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \
         --ssl-ca=mysql-ssl-ca-cert.pem <database_name> < cakephp_cloudcontrol_init.sql
 
-In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem](http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
+In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem](https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
 
     mysql -u <database_username> -p \
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \

--- a/Guides/PHP/Drupal 7.md
+++ b/Guides/PHP/Drupal 7.md
@@ -240,7 +240,7 @@ Now, in the shell, we're going to load the data in to the remote mysql instance 
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \
         --ssl-ca=mysql-ssl-ca-cert.pem <database_name> < drupal_cloudcontrol_init.sql
 
-In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem](http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
+In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem](https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
 
     mysql -u <database_username> -p \
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \

--- a/Guides/PHP/Joomla 2.5.md
+++ b/Guides/PHP/Joomla 2.5.md
@@ -229,7 +229,7 @@ Now, in the shell, we're going to dump the database that the install routine cre
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \
         --ssl-ca=mysql-ssl-ca-cert.pem <database_name> < joomla_cloudcontrol_init.sql
 
-In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem](http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
+In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem](https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
 
     mysql -u <database_username> -p \
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \

--- a/Guides/PHP/Kohana 3.2.0.md
+++ b/Guides/PHP/Kohana 3.2.0.md
@@ -411,7 +411,7 @@ Now, in the shell, we're going to load the schema in to the remote mysql instanc
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \
         --ssl-ca=mysql-ssl-ca-cert.pem <database_name> < kohana_cloudcontrol_init.sql
 
-In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem](http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
+In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem](https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
 
     mysql -u <database_username> -p \
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \

--- a/Guides/PHP/Yii 1.1.10.md
+++ b/Guides/PHP/Yii 1.1.10.md
@@ -299,7 +299,7 @@ Now, in the shell, we're going to load the data in to the remote mysql instance 
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \
         --ssl-ca=mysql-ssl-ca-cert.pem <database_name> < Yii Framework_cloudcontrol_init.sql
 
-In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem](http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
+In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem](https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
 
     mysql -u <database_username> -p \
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \

--- a/Guides/PHP/Zend Framework 1.11.md
+++ b/Guides/PHP/Zend Framework 1.11.md
@@ -438,7 +438,7 @@ Now, in the shell, we're going to load the data in to the remote mysql instance 
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \
         --ssl-ca=mysql-ssl-ca-cert.pem <database_name> < zendframework_cloudcontrol_init.sql
 
-In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem](http://s3.amazonaws.com/rds-downloads/mysql-ssl-ca-cert.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
+In the command above, you can see a reference to a **.pem** file. This can be downloaded from: [https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem](https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem). All being well, the command will finish silently, loading the data. You can check that all's gone well with following commands:
 
     mysql -u <database_username> -p \
         -h mysqlsdb.co8hm2var4k9.eu-west-1.rds.amazonaws.com \


### PR DESCRIPTION
Users have to use the new certificate as of today. Update the download
link and point to the complete, "offical" certificate bundle by AWS RDS.