### PR TITLE
Update instructions for pip installation

### DIFF
--- a/Platform-Documentation.md
+++ b/Platform-Documentation.md
@@ -26,10 +26,13 @@ On Linux and Mac OS we recommend installing and updating cctrl via pip. *cctrl* 
 $ sudo pip install -U cctrl
 ~~~
 
-If you don't have pip you can install pip via easy_install (on Linux usually part of the python-setuptools package) and then install cctrl.
+If you don't have pip, you can install it either using packages from
+your distribution or following the instructions in
+[pip documentation](https://pip.pypa.io/en/stable/installing/). For
+example, on Ubuntu, use:
 
 ~~~
-$ sudo easy_install pip
+$ sudo apt-get install python-pip python-dev
 $ sudo pip install -U cctrl
 ~~~
 

--- a/Quickstart.md
+++ b/Quickstart.md
@@ -20,9 +20,16 @@ Install Git from the [official site](http://git-scm.com/) or your package reposi
 **Linux/Mac OS X:** We recommend installing cctrl via pip.
 
 ~~~bash
-# if you don't have pip yet
-$ sudo easy_install pip
 $ sudo pip install cctrl
+~~~
+
+If you don't have pip, you can install it either using packages from
+your distribution or following the instructions in
+[pip documentation](https://pip.pypa.io/en/stable/installing/). For
+example, on Ubuntu, use:
+
+~~~bash
+$ sudo apt-get install python-pip python-dev
 ~~~
 
 **Windows:** Please download the provided [installer](https://download.cloudcontrolled.com/windows).


### PR DESCRIPTION
Using easy_install is deprecated. On a modern Ubuntu, it just won't
work. Instead, using Ubuntu package or the official pip installer is
preferable. On Ubuntu, the python-dev package is also needed for
pycrypto which doesn't ship a pre-compiled wheel.
